### PR TITLE
[libcontentaction] Fixes NB#457 - Cut libmeegotouch dependency out of the libcontentaction

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,8 @@ PKG_CHECK_MODULES([QtDBus], [QtDBus])
 PKG_CHECK_MODULES([QtSystemInfo], [QtSystemInfo])
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.12.0])
 PKG_CHECK_MODULES([GIO], [gio-2.0 gio-unix-2.0])
-PKG_CHECK_MODULES([MT], [meegotouch >= 0.20])
+PKG_CHECK_MODULES([MLITE], [mlite >= 0.0.6])
+PKG_CHECK_MODULES([MLOCALE], [mlocale >= 0.1])
 
 # tools for documentation
 AX_FEATURE_DISABLEABLE([doc], [BUILD_DOCS], [disable building of documentation])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,8 @@ AM_CPPFLAGS = \
 	$(QtDBus_CFLAGS) \
 	$(QtSystemInfo_CFLAGS) \
 	$(GIO_CFLAGS) \
-	$(MT_CFLAGS) \
+	$(MLITE_CFLAGS) \
+	$(MLOCALE_CFLAGS) \
 	-DDEFAULT_ACTIONS=\"@datadir@/contentaction\" \
 	-DDEFAULT_L10N_DIR=\"@datadir@/contentaction/l10n\" \
 	-DLCA_BUILD
@@ -36,7 +37,8 @@ LIBS += \
 	$(QtDBus_LIBS) \
 	$(QtSystemInfo_LIBS) \
 	$(GIO_LIBS) \
-	$(MT_LIBS)
+	$(MLITE_LIBS) \
+	$(MLOCALE_LIBS)
 
 incdir = $(includedir)/contentaction
 inc_HEADERS = \

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -27,10 +27,6 @@
 #include <QModelIndex>
 #include <QAbstractListModel>
 
-#include <MLabel>
-#include <MLabelHighlighter>
-#include <MPopupList>
-
 typedef QPair<QString, const QRegExp &> MimeAndRegexp;
 typedef QList<MimeAndRegexp> MimesAndRegexps;
 
@@ -38,23 +34,6 @@ namespace {
 
 using namespace ContentAction;
 using namespace ContentAction::Internal;
-
-class LCALabelHighlighter: public MCommonLabelHighlighter
-{
-    Q_OBJECT
-public:
-    LCALabelHighlighter(const MimesAndRegexps &mars_,
-                        QObject *parent = 0);
-private Q_SLOTS:
-    void doDefaultAction(const QString& match);
-    void doPopupActions(const QString& match);
-    void doAction(const QModelIndex& ix);
-private:
-    QStringList matchingMimes(const QString &str) const;
-    MimesAndRegexps mars;
-};
-
-LCALabelHighlighter* DefaultHighlighter = 0;
 
 MimesAndRegexps regExpsInUse()
 {
@@ -87,118 +66,6 @@ QRegExp combine(const MimesAndRegexps &mars)
     return QRegExp(re);
 }
 
-LCALabelHighlighter::LCALabelHighlighter(const MimesAndRegexps &mars_,
-                                         QObject *parent) :
-    MCommonLabelHighlighter(combine(mars_)),
-    mars(mars_)
-{
-    if (parent)
-        setParent(parent);
-    QObject::connect(this, SIGNAL(clicked(const QString&)),
-                     this, SLOT(doDefaultAction(const QString&)));
-    QObject::connect(this, SIGNAL(longPressed(const QString&)),
-                     this, SLOT(doPopupActions(const QString&)));
-}
-
-/// Returns the mimes that match the given string, and are processed by this
-/// LCALabelHighlighter.  (Note that the LCALabelHighlighter doesn't necessarily
-/// handle all regexps.)
-QStringList LCALabelHighlighter::matchingMimes(const QString &str) const
-{
-    // TODO: the code is a bit duplicate with Internal::mimeForString but not
-    // quite.
-    QStringList ret;
-    Q_FOREACH (const MimeAndRegexp &mr, mars)
-        if (mr.second.exactMatch(str))
-            ret.append(mr.first);
-    return ret;
-}
-
-void LCALabelHighlighter::doDefaultAction(const QString& match)
-{
-    QStringList mimes = matchingMimes(match);
-    QString app;
-    Q_FOREACH (const QString &mime, mimes) {
-        app = findDesktopFile(defaultAppForContentType(mime));
-        if (!app.isEmpty()) {
-            createAction(app, QStringList() << match).trigger();
-            return;
-        }
-    }
-    Q_FOREACH (const QString &mime, mimes) {
-        QStringList apps = appsForContentType(mime);
-        Q_FOREACH (const QString& appid, apps) {
-            app = findDesktopFile(appid);
-            if (!app.isEmpty()) {
-                createAction(app, QStringList() << match).trigger();
-                return;
-            }
-        }
-    }
-}
-
-struct ActionListModel: public QAbstractListModel
-{
-    Q_OBJECT
-public:
-
-    enum { ActionRole = Qt::UserRole + 1 };
-
-    ActionListModel(const QList<Action>& actions, QObject *parent = 0) :
-        QAbstractListModel(parent),
-        actions(actions)
-        { }
-    virtual int rowCount(const QModelIndex& parent) const
-        {
-            return actions.count();
-        }
-    virtual QVariant data(const QModelIndex& ix, int role) const
-        {
-            QVariant ret;
-
-            if (!ix.isValid() || ix.row() >= actions.count())
-                return ret;
-            if (role == Qt::DisplayRole)
-                ret = actions.at(ix.row()).localizedName();
-            else if (role == ActionRole)
-                ret.setValue(actions.at(ix.row()));
-            return ret;
-        }
-
-    QList<Action> actions;
-};
-
-void LCALabelHighlighter::doAction(const QModelIndex& ix)
-{
-    Action a = ix.model()->data(ix, ActionListModel::ActionRole).value<Action>();
-    a.trigger();
-}
-
-void LCALabelHighlighter::doPopupActions(const QString& match)
-{
-    qRegisterMetaType<Action>();
-    QList<Action> alist;
-    QStringList mimes = matchingMimes(match);
-    QString app;
-    Q_FOREACH (const QString &mime, mimes) {
-        Q_FOREACH (const QString &appid, appsForContentType(mime)) {
-            app = findDesktopFile(appid);
-            if (!app.isEmpty())
-                alist << createAction(app, QStringList() << match);
-        }
-    }
-
-    MPopupList *popuplist = new MPopupList();
-    popuplist->setItemModel(new ActionListModel(alist, popuplist));
-    popuplist->setTitle(match);
-    popuplist->setTitleBarVisible(true);
-    connect(popuplist, SIGNAL(clicked(const QModelIndex&)),
-            this, SLOT(doAction(const QModelIndex&)));
-    connect(popuplist, SIGNAL(finished(int)),
-            popuplist, SLOT(deleteLater()));
-    popuplist->appear();
-}
-
 } // end anon namespace
 
 namespace ContentAction {
@@ -217,72 +84,6 @@ QRegExp masterRegexp()
 
 } // end namespace Internal
 } // end namespace ContentAction
-
-/// Attaches a MLabelHighlighter to the label, based on the highlighter
-/// configuration.  The MLabelHighlighter contains a regexp which is constructed
-/// by combining all regexps in the highlighter configuration.  Clicking on a
-/// highlighted label invokes the first action defined for the matching pattern.
-/// A long-click causes a popup list to be shown with the possible actions, from
-/// where the user may choose one.
-void ContentAction::highlightLabel(MLabel *label)
-{
-    if (label->property("_lca_highlighter").isValid())
-        return;
-
-    // This highlights the label with the default highlighter.  The default
-    // highlighter is not deleted when the label is unhighlighted.
-    if (DefaultHighlighter == 0) {
-        DefaultHighlighter = new LCALabelHighlighter(regExpsInUse());
-    }
-    label->addHighlighter(DefaultHighlighter);
-    label->setProperty("_lca_highlighter",
-                       QVariant::fromValue<void *>(DefaultHighlighter));
-}
-
-/// Similar to highlightLabel() but allows specifying which regexp-types to
-/// highlight (e.g. only \c "x-maemo-highlight/mailto"). The order of the \a
-/// typesOfHighlight is honoured; the regexps appearing first get the priority
-/// when deciding the default action and the order of the actions.
-void ContentAction::highlightLabel(MLabel *label,
-                                   QStringList typesToHighlight)
-{
-    if (label->property("_lca_highlighter").isValid())
-        return;
-
-    // Don't use the default highlighter (which uses all the regexps), but
-    // create another one which uses only a subset of them.
-    MimesAndRegexps mars;
-    const QList<QPair<QString, QRegExp> >& cfgList = highlighterConfig();
-    QMap<QString, const QRegExp *> cfgMap;
-    for (int i = 0; i < cfgList.size(); ++i)
-        cfgMap.insert(cfgList[i].first, &cfgList[i].second);
-    Q_FOREACH (const QString& k, typesToHighlight) {
-        QMap<QString, const QRegExp *>::const_iterator it(cfgMap.find(k));
-        if (it == cfgMap.end())
-            continue;
-        if (!appsForContentType(k).isEmpty())
-            mars += MimeAndRegexp(k, **it);
-    }
-
-    if (mars.isEmpty())
-        return;
-    LCALabelHighlighter *hl = new LCALabelHighlighter(mars, label);
-    label->addHighlighter(hl);
-    label->setProperty("_lca_highlighter", QVariant::fromValue<void *>(hl));
-}
-
-/// Removes all highlighters attached by highlightLabel() from \a label.
-void ContentAction::dehighlightLabel(MLabel *label)
-{
-    QVariant prop = label->property("_lca_highlighter");
-    if (!prop.isValid())
-        return;
-    LCALabelHighlighter *hl = static_cast<LCALabelHighlighter *>(prop.value<void *>());
-    label->removeHighlighter(hl);
-    if (hl != DefaultHighlighter)
-        delete hl;
-    label->setProperty("_lca_highlighter", QVariant());
-}
 
 Q_DECLARE_METATYPE(ContentAction::Action);
 

--- a/src/lca-tool.cpp
+++ b/src/lca-tool.cpp
@@ -27,7 +27,7 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <QFileInfo>
-#include <MLocale>
+#include <mlocale/MLocale>
 
 using namespace ContentAction;
 using namespace ContentAction::Internal;
@@ -203,10 +203,10 @@ int main(int argc, char **argv)
     if (l10npaths) {
         Q_FOREACH (const QString& p, QString::fromLocal8Bit(l10npaths).split(':')) {
             qDebug() << "adding path:" << p;
-            MLocale::addTranslationPath(p);
+            ML10N::MLocale::addTranslationPath(p);
         }
     } else {
-        MLocale::addTranslationPath("/usr/share/l10n/meegotouch");
+        ML10N::MLocale::addTranslationPath("/usr/share/l10n/meegotouch");
     }
 
     QStringList args;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -74,17 +74,6 @@ check_PROGRAMS = \
 
 BUILT_SOURCES += test-action.moc test-info.moc
 
-noinst_PROGRAMS = hldemo
-hldemo_SOURCES = hldemo.cpp
-hldemo_CPPFLAGS = \
-	$(MT_CFLAGS) \
-	-I$(top_srcdir)/src
-hldemo_LDADD = \
-	$(MT_LIBS) \
-	../src/libcontentaction.la
-BUILT_SOURCES += hldemo.moc
-CLEANFILES += hldemo.moc
-
 testhelperdir = $(libdir)/libcontentaction-tests
 testhelper_PROGRAMS = \
 	servicetest
@@ -120,6 +109,14 @@ test_mimedefaults_CPPFLAGS = \
 
 test_mimedefaults_LDADD = \
 	$(QtTest_LIBS)
+
+test_info_SOURCES = \
+	test-info.cpp \
+	test-info.moc
+
+test_action_SOURCES = \
+	test-action.cpp \
+	test-action.moc
 
 BUILT_SOURCES += servicelistener.moc \
 	test-findhighlights.moc \


### PR DESCRIPTION
Removes the dependency to libmeegotouch. MeeGo Touch highlighter is no longer available.
